### PR TITLE
Fixed Conjugation in README Citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The [slides](https://drive.google.com/open?id=1_Sp3ZagAKd5xrtBX0IeQYqDZM9trNiqm)
                Weihang Wang and
                Xiangyu Zhang},
   title     = {Trojaning Attack on Neural Networks},
-  booktitle = {25nd Annual Network and Distributed System Security Symposium, {NDSS}
+  booktitle = {25th Annual Network and Distributed System Security Symposium, {NDSS}
                2018, San Diego, California, USA, February 18-221, 2018},
   publisher = {The Internet Society},
   year      = {2018},


### PR DESCRIPTION
It previously said "25nd" but the correct conjugation for "25" is "th" as fixed above.